### PR TITLE
Fix group membership invitation flow

### DIFF
--- a/models/group/group.js
+++ b/models/group/group.js
@@ -1,5 +1,5 @@
 import { addDoc, collection, query, where, getDocs, or, updateDoc, doc, arrayUnion } from "firebase/firestore";
-import { app, db } from "../../firebase"; 
+import { app, db } from "../../firebase";
 
 class Group{
     name;
@@ -20,11 +20,14 @@ class Group{
 
     // function to create the group and save it to firebase collection groups
     async creatGroup(name, created_by, currency, members, description) {
+        const memberIds = members.map(m => (typeof m === 'string' ? m : m.id));
+
         const groupData = {
             name,
             created_by,
             currency,
             members,
+            memberIds,
             created_at: new Date().toISOString(),
             description,
         };
@@ -44,7 +47,7 @@ class Group{
             GroupsCollection,
             or(
                 where("created_by", "==", user_id),
-                where("members", "array-contains", user_id)
+                where("memberIds", "array-contains", user_id)
             )
         );
         const querySnapshot = await getDocs(q);
@@ -55,10 +58,12 @@ class Group{
         return groups;
     }
 
-    static async addMemberToGroup(groupId, userId) {
+    static async addMemberToGroup(groupId, member) {
         const groupRef = doc(db, "groups", groupId);
+        const memberId = typeof member === 'string' ? member : member.id;
         await updateDoc(groupRef, {
-        members: arrayUnion(userId),
+        members: arrayUnion(member),
+        memberIds: arrayUnion(memberId),
         });
     }
 

--- a/screens/Main/AddNewGroupScreen.js
+++ b/screens/Main/AddNewGroupScreen.js
@@ -75,13 +75,24 @@ const AddNewGroupScreen = () => {
       const currency = 'MAD';
       const description = '';
 
-      // Create group
+      // Fetch current user's info to include as initial member
+      const currentUserDetails = await User.getUserDetails();
+      const creatorMember = {
+        id: created_by,
+        name: currentUserDetails.username,
+        initial: currentUserDetails.username
+          ? currentUserDetails.username[0].toUpperCase()
+          : '',
+        color: '#2979FF',
+      };
+
+      // Create group with only the creator as a member
       const groupInstance = new Group();
       const groupId = await groupInstance.creatGroup(
         groupName,
         created_by,
         currency,
-        selectedMembers,
+        [creatorMember],
         description
       );
 

--- a/screens/Main/GroupsScreen.js
+++ b/screens/Main/GroupsScreen.js
@@ -198,8 +198,17 @@ const GroupsScreen = () => {
 
   const handleAcceptInvitation = async (invId, groupId) => {
     try {
-      // 1) add to group
-      await Group.addMemberToGroup(groupId, userId);
+      // 1) build member object for the current user
+      const username = await User.getUsernameById(userId);
+      const memberObj = {
+        id: userId,
+        name: username,
+        initial: username ? username[0].toUpperCase() : '',
+        color: '#2979FF',
+      };
+
+      // add to group
+      await Group.addMemberToGroup(groupId, memberObj);
 
       // 2) mark invitation accepted
       await Invitation.accept(invId);


### PR DESCRIPTION
## Summary
- ensure new groups only include the creator as a member
- track member IDs separately for efficient lookups
- add member details after invitation acceptance

## Testing
- `npm -s run lint` *(fails: Cannot find module 'eslint/config')*
- `npm -s run test`

------
https://chatgpt.com/codex/tasks/task_e_684f0251b31c83309877dc2063eee5b4