### PR TITLE
Implement group notifications

### DIFF
--- a/components/NotificationItem.js
+++ b/components/NotificationItem.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+const NotificationItem = ({ notification }) => {
+  const { message, created_at } = notification;
+  const time = created_at?.toDate ? created_at.toDate().toLocaleString() : new Date(created_at).toLocaleString();
+
+  return (
+    <View className="mb-3 rounded-lg border border-gray-100 bg-white p-4">
+      <Text className="text-base text-black" numberOfLines={2}>{message}</Text>
+      <Text className="mt-1 text-xs text-gray-500">{time}</Text>
+    </View>
+  );
+};
+
+export default NotificationItem;

--- a/models/group/group.js
+++ b/models/group/group.js
@@ -1,4 +1,4 @@
-import { addDoc, collection, query, where, getDocs, or, updateDoc, doc, arrayUnion } from "firebase/firestore";
+import { addDoc, collection, query, where, getDocs, or, updateDoc, doc, arrayUnion, getDoc } from "firebase/firestore";
 import { app, db } from "../../firebase";
 import Notification from "models/notifications/notifications";
 
@@ -75,6 +75,15 @@ class Group{
         members: arrayUnion(member),
         memberIds: arrayUnion(memberId),
         });
+    }
+
+    static async getGroupById(groupId) {
+        const ref = doc(db, 'groups', groupId);
+        const snap = await getDoc(ref);
+        if (!snap.exists()) {
+            throw new Error('Group not found');
+        }
+        return { id: snap.id, ...snap.data() };
     }
 
     

--- a/screens/Main/NotificationsScreen.js
+++ b/screens/Main/NotificationsScreen.js
@@ -1,7 +1,8 @@
 import Header from 'components/Header'
 import React, { useEffect, useState } from 'react'
-import { SafeAreaView, Text, View } from 'react-native'
+import { SafeAreaView, View, ScrollView } from 'react-native'
 import Notification from 'models/notifications/notifications'
+import NotificationItem from 'components/NotificationItem'
 
 const NotificationsScreen = () => {
     const [notifications, setNotifications] = useState([])
@@ -23,9 +24,13 @@ const NotificationsScreen = () => {
     }, []);
   return (
     <SafeAreaView className="flex-1 bg-white">
-        <View>
-            <Header title="All Expenses" />
-            <Text>Notifications Screen</Text>
+        <View className="flex-1">
+            <Header title="Notifications" />
+            <ScrollView className="px-4" showsVerticalScrollIndicator={false}>
+                {notifications.map((n) => (
+                    <NotificationItem key={n.id} notification={n} />
+                ))}
+            </ScrollView>
         </View>
     </SafeAreaView>
   )


### PR DESCRIPTION
## Summary
- support optional group and expense fields on notifications
- fetch notifications ordered by date
- notify invited users and creators when invitations are accepted
- notify all members when a group expense is created
- expose a helper to fetch a group by id
- show fetched notifications in a list

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_e_68529530b11883309a58f54d2bc4f347