### PR TITLE
Add i18n support with Arabic, English and French

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,7 @@
 import { AuthProvider } from 'utils/AuthContext';
 import './global.css';
+import i18n from 'utils/i18n';
+import { I18nextProvider } from 'react-i18next';
 import { NavigationContainer } from '@react-navigation/native';
 import AppNavigator from 'utils/AppNavigator';
 import {
@@ -40,9 +42,11 @@ export default function App() {
 
   return (
     <AuthProvider>
-      <NavigationContainer>
-        <AppNavigator />
-      </NavigationContainer>
+      <I18nextProvider i18n={i18n}>
+        <NavigationContainer>
+          <AppNavigator />
+        </NavigationContainer>
+      </I18nextProvider>
     </AuthProvider>
   );
 }

--- a/screens/Auth/LoginScreen.js
+++ b/screens/Auth/LoginScreen.js
@@ -13,9 +13,12 @@ import { Logo } from 'components/Logo';
 import { BackButton } from 'components/BackButton';
 import { useNavigation } from '@react-navigation/native';
 import Login from 'models/auth/Login';
+import { useTranslation } from 'react-i18next';
+import i18n from 'utils/i18n';
 
 const LoginScreen = () => {
   const navigation = useNavigation();
+  const { t } = useTranslation();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -85,16 +88,14 @@ const LoginScreen = () => {
           </View>
           {/* Title and Subtitle */}
           <View>
-            <Text className="title">Login</Text>
-            <Text className="subtitle">
-              Please enter your email and password to enjoy the experience
-            </Text>
+            <Text className="title">{t('login.title')}</Text>
+            <Text className="subtitle">{t('login.subtitle')}</Text>
           </View>
           {/* Form */}
           <View className="form-container">
             <View className="gap-4">
               <View className="input-group">
-                <Text className="input-label">Email</Text>
+                <Text className="input-label">{t('login.email')}</Text>
                 <View className="input-container">
                   <Ionicons
                     name="mail-outline"
@@ -128,7 +129,7 @@ const LoginScreen = () => {
               </View>
 
               <View className="input-group">
-                <Text className="input-label">Password</Text>
+                <Text className="input-label">{t('login.password')}</Text>
                 <View className="input-container">
                   <Ionicons
                     name="lock-closed-outline"
@@ -172,16 +173,16 @@ const LoginScreen = () => {
             </View>
 
             <TouchableOpacity onPress={() => navigation.navigate('ForgotPassword')}>
-              <Text className="forgot-password-link">Forget Password?</Text>
+              <Text className="forgot-password-link">{t('login.forgot_password')}</Text>
             </TouchableOpacity>
 
             <TouchableOpacity className="btn-primary" onPress={handleLogin} disabled={isLoading}>
-              <Text className="btn-primary-text">{isLoading ? 'Logging in...' : 'Login'}</Text>
+              <Text className="btn-primary-text">{isLoading ? t('login.logging_in') : t('login.login_button')}</Text>
             </TouchableOpacity>
           </View>
           <View className="divider-container">
             <View className="divider-line" />
-            <Text className="divider-text">Or Continue with</Text>
+            <Text className="divider-text">{t('login.or_continue_with')}</Text>
             <View className="divider-line" />
           </View>
           <View className="flex w-full flex-row gap-4">
@@ -191,19 +192,19 @@ const LoginScreen = () => {
                 className="h-5 w-5"
                 resizeMode="contain"
               />
-              <Text className="text-label">Google</Text>
+              <Text className="text-label">{t('login.google')}</Text>
             </TouchableOpacity>
 
             <TouchableOpacity className="social-button" onPress={() => handleSocialLogin('Apple')}>
               <Ionicons name="logo-apple" size={20} color="#000000" />
-              <Text className="text-label">Apple</Text>
+              <Text className="text-label">{t('login.apple')}</Text>
             </TouchableOpacity>
           </View>
           {/* Sign Up Link - UNCOMMENTED */}
           <View className="signup-container">
-            <Text className="signup-text">Didn&apos;t have an account? </Text>
+            <Text className="signup-text">{t('login.no_account')}</Text>
             <TouchableOpacity onPress={() => navigation.navigate('Register')}>
-              <Text className="signup-link">Sign Up</Text>
+              <Text className="signup-link">{t('login.sign_up')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/screens/Auth/RegisterScreen.js
+++ b/screens/Auth/RegisterScreen.js
@@ -18,9 +18,12 @@ import { BackButton } from 'components/BackButton';
 import { useNavigation } from '@react-navigation/native';
 import Register from 'models/auth/Register';
 import User from 'models/auth/user';
+import { useTranslation } from 'react-i18next';
+import i18n from 'utils/i18n';
 
 const RegisterScreen = () => {
   const navigation = useNavigation();
+  const { t } = useTranslation();
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -168,8 +171,8 @@ const RegisterScreen = () => {
 
             {/* Title and Subtitle */}
             <View className="">
-              <Text className="title">Create an Account</Text>
-              <Text className="subtitle">Please enter your details to enjoy the experience</Text>
+              <Text className="title">{t('register.title')}</Text>
+              <Text className="subtitle">{t('register.subtitle')}</Text>
             </View>
 
             {/* Form */}
@@ -177,7 +180,7 @@ const RegisterScreen = () => {
               <View className="gap-4">
                 {/* Username Input */}
                 <View className="input-group">
-                  <Text className="input-label">Username</Text>
+                  <Text className="input-label">{t('register.username')}</Text>
                   <View className="input-container">
                     <Ionicons
                       name="person-outline"
@@ -211,7 +214,7 @@ const RegisterScreen = () => {
 
                 {/* Email Input */}
                 <View className="input-group">
-                  <Text className="input-label">Email</Text>
+                  <Text className="input-label">{t('register.email')}</Text>
                   <View className="input-container">
                     <Ionicons
                       name="mail-outline"
@@ -246,7 +249,7 @@ const RegisterScreen = () => {
 
                 {/* Password Input */}
                 <View className="input-group">
-                  <Text className="input-label">Password</Text>
+                  <Text className="input-label">{t('register.password')}</Text>
                   <View className="input-container">
                     <Ionicons
                       name="lock-closed-outline"
@@ -362,7 +365,7 @@ const RegisterScreen = () => {
 
                 {/* Confirm Password Input */}
                 <View className="input-group">
-                  <Text className="input-label">Confirm Password</Text>
+                  <Text className="input-label">{t('register.confirm_password')}</Text>
                   <View className="input-container">
                     <Ionicons
                       name="lock-closed-outline"
@@ -434,7 +437,7 @@ const RegisterScreen = () => {
                   }`}>
                   {rememberMe && <Ionicons name="checkmark" size={14} color="white" />}
                 </View>
-                <Text className="font-medium text-body text-primary">Remember me</Text>
+                <Text className="font-medium text-body text-primary">{t('register.remember_me')}</Text>
               </TouchableOpacity>
 
               <TouchableOpacity
@@ -442,14 +445,14 @@ const RegisterScreen = () => {
                 onPress={handleRegister}
                 disabled={isLoading}>
                 <Text className="btn-primary-text">
-                  {isLoading ? 'Creating Account...' : 'Create an Account'}
+                  {isLoading ? t('register.creating_account') : t('register.create_account')}
                 </Text>
               </TouchableOpacity>
             </View>
 
             <View className="divider-container">
               <View className="divider-line" />
-              <Text className="divider-text">OR use</Text>
+              <Text className="divider-text">{t('register.or_use')}</Text>
               <View className="divider-line" />
             </View>
 
@@ -463,22 +466,22 @@ const RegisterScreen = () => {
                   className="w-5 h-5"
                   resizeMode="contain"
                 />
-                <Text className="text-label">Google</Text>
+                <Text className="text-label">{t('register.google')}</Text>
               </TouchableOpacity>
 
               <TouchableOpacity
                 className="social-button"
                 onPress={() => handleSocialLogin('Apple')}>
                 <Ionicons name="logo-apple" size={20} color="#000000" />
-                <Text className="text-label">Apple</Text>
+                <Text className="text-label">{t('register.apple')}</Text>
               </TouchableOpacity>
             </View>
 
             {/* Login Link */}
             <View className="mt-6 signup-container">
-              <Text className="signup-text">Already have an account? </Text>
+              <Text className="signup-text">{t('register.already_have_account')}</Text>
               <TouchableOpacity onPress={() => navigation.navigate('Login')}>
-                <Text className="signup-link">Log In</Text>
+                <Text className="signup-link">{t('register.login')}</Text>
               </TouchableOpacity>
             </View>
           </View>

--- a/screens/Main/LanguagesScreen.js
+++ b/screens/Main/LanguagesScreen.js
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, SafeAreaView, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { BackButton } from 'components/BackButton';
 import { useNavigation } from '@react-navigation/native';
 import Header from 'components/Header';
+import { useTranslation } from 'react-i18next';
+import i18n from 'utils/i18n';
 
 const LanguagesScreen = () => {
   const navigation = useNavigation();
-  const [selectedLanguage, setSelectedLanguage] = useState('English');
+  const { t } = useTranslation();
+  const [selectedLanguage, setSelectedLanguage] = useState(i18n.language);
   const [isLoading, setIsLoading] = useState(false);
 
   const languages = [
@@ -43,20 +45,19 @@ const LanguagesScreen = () => {
     }, */
   ];
 
-  const handleLanguageSelect = (language) => {
-    setSelectedLanguage(language.name);
+  const handleLanguageSelect = language => {
+    setSelectedLanguage(language.code);
   };
 
   const handleChangeLanguage = async () => {
     setIsLoading(true);
     try {
-      // Add your language change logic here
-      // await Language.changeLanguage(selectedLanguage);
-      Alert.alert('Success', `Language changed to ${selectedLanguage}`);
+      await i18n.changeLanguage(selectedLanguage);
+      Alert.alert(t('languages.success_title'), t('languages.success_message'));
       navigation.goBack();
     } catch (error) {
       console.error('Language change failed:', error.message);
-      Alert.alert('Error', 'Failed to change language. Please try again.');
+      Alert.alert(t('languages.error_title'), t('languages.error_message'));
     } finally {
       setIsLoading(false);
     }
@@ -68,8 +69,8 @@ const LanguagesScreen = () => {
         className="container"
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ flexGrow: 1 }}>
-        <Header title="Languages" />
-        <Text className="text-sm font-normal">Change the app language.</Text>
+        <Header title={t('languages.title')} />
+        <Text className="text-sm font-normal">{t('languages.subtitle')}</Text>
         <View className="relative pt-4">
           <View className="form-container">
             {/* Language Options */}
@@ -78,7 +79,7 @@ const LanguagesScreen = () => {
                 <TouchableOpacity
                   key={language.code}
                   className={`mb-2 flex-row items-center justify-between rounded-lg border p-4 ${
-                    selectedLanguage === language.name
+                    selectedLanguage === language.code
                       ? 'border-blue-500 bg-blue-50'
                       : 'border-gray-200 bg-white'
                   }`}
@@ -88,7 +89,7 @@ const LanguagesScreen = () => {
                     <View>
                       <Text
                         className={`text-lg font-medium ${
-                          selectedLanguage === language.name ? 'text-blue-600' : 'text-black'
+                          selectedLanguage === language.code ? 'text-blue-600' : 'text-black'
                         }`}>
                         {language.name}
                       </Text>
@@ -98,11 +99,11 @@ const LanguagesScreen = () => {
 
                   <View
                     className={`h-6 w-6 items-center justify-center rounded-full border-2 ${
-                      selectedLanguage === language.name
+                      selectedLanguage === language.code
                         ? 'border-blue-500 bg-blue-500'
                         : 'border-gray-300'
                     }`}>
-                    {selectedLanguage === language.name && (
+                    {selectedLanguage === language.code && (
                       <Ionicons name="checkmark" size={16} color="white" />
                     )}
                   </View>
@@ -115,7 +116,7 @@ const LanguagesScreen = () => {
               onPress={handleChangeLanguage}
               disabled={isLoading}>
               <Text className="btn-primary-text">
-                {isLoading ? 'Changing...' : 'Change language'}
+                {isLoading ? t('languages.changing') : t('languages.change')}
               </Text>
             </TouchableOpacity>
           </View>

--- a/screens/Main/SettingsScreen.js
+++ b/screens/Main/SettingsScreen.js
@@ -12,9 +12,12 @@ import { Ionicons } from '@expo/vector-icons';
 import { BackButton } from 'components/BackButton';
 import { useNavigation } from '@react-navigation/native';
 import Header from 'components/Header';
+import { useTranslation } from 'react-i18next';
+import i18n from 'utils/i18n';
 
 const SettingsScreen = () => {
   const navigation = useNavigation();
+  const { t } = useTranslation();
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
   const [selectedCurrency, setSelectedCurrency] = useState('MAD');
   const [isLoading, setIsLoading] = useState(false);
@@ -52,8 +55,8 @@ const SettingsScreen = () => {
         className="container"
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ flexGrow: 1 }}>
-        <Header title="Settings" />
-        <Text className="text-sm font-normal">Customize app preferences.</Text>
+        <Header title={t('settings.title')} />
+        <Text className="text-sm font-normal">{t('settings.subtitle')}</Text>
         <View className="relative pt-4">
           <View className="form-container">
             {/* Notifications Setting */}
@@ -62,7 +65,7 @@ const SettingsScreen = () => {
                 <View className="items-center justify-center w-10 h-10 ">
                   <Ionicons name="notifications-outline" size={20} color="#666" />
                 </View>
-                <Text className="text-lg font-normal text-black">Notifications</Text>
+                <Text className="text-lg font-normal text-black">{t('settings.notifications')}</Text>
               </View>
               <Switch
                 value={notificationsEnabled}
@@ -75,7 +78,7 @@ const SettingsScreen = () => {
 
             {/* Currency Setting */}
             <View className="mb-6">
-              <Text className="mb-2 input-label">Currency</Text>
+              <Text className="mb-2 input-label">{t('settings.currency')}</Text>
               <TouchableOpacity
                 className="input-container"
                 onPress={() => setShowCurrencyDropdown(!showCurrencyDropdown)}>
@@ -118,7 +121,7 @@ const SettingsScreen = () => {
               className="btn-primary"
               onPress={handleUpdateSettings}
               disabled={isLoading}>
-              <Text className="btn-primary-text">{isLoading ? 'Updating...' : 'Update Info'}</Text>
+              <Text className="btn-primary-text">{isLoading ? t('settings.updating') : t('settings.update_info')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/utils/i18n.js
+++ b/utils/i18n.js
@@ -1,16 +1,36 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import en from './locales/en/translation.json';
 import ar from './locales/ar/translation.json';
+import fr from './locales/fr/translation.json';
+
+const LANGUAGE_PREFERENCE = 'appLanguage';
+
+const languageDetector = {
+  type: 'languageDetector',
+  async: true,
+  detect: async callback => {
+    const saved = await AsyncStorage.getItem(LANGUAGE_PREFERENCE);
+    const lng = saved || 'en';
+    callback(lng);
+  },
+  init: () => {},
+  cacheUserLanguage: async lng => {
+    await AsyncStorage.setItem(LANGUAGE_PREFERENCE, lng);
+  },
+};
 
 i18n
+  .use(languageDetector)
   .use(initReactI18next)
   .init({
     compatibilityJSON: 'v3',
     resources: {
       en: { translation: en },
       ar: { translation: ar },
+      fr: { translation: fr },
     },
     lng: 'en', // default language
     fallbackLng: 'en',

--- a/utils/locales/ar/translation.json
+++ b/utils/locales/ar/translation.json
@@ -1,0 +1,50 @@
+{
+  "languages": {
+    "title": "اللغات",
+    "subtitle": "تغيير لغة التطبيق.",
+    "change": "تغيير اللغة",
+    "changing": "جارٍ التغيير...",
+    "success_title": "نجاح",
+    "success_message": "تم تغيير اللغة بنجاح",
+    "error_title": "خطأ",
+    "error_message": "فشل تغيير اللغة. حاول مرة أخرى."
+  },
+  "login": {
+    "title": "تسجيل الدخول",
+    "subtitle": "يرجى إدخال البريد الإلكتروني وكلمة المرور للاستمتاع بالتطبيق",
+    "email": "البريد الإلكتروني",
+    "password": "كلمة المرور",
+    "forgot_password": "هل نسيت كلمة المرور؟",
+    "login_button": "تسجيل الدخول",
+    "logging_in": "جارٍ تسجيل الدخول...",
+    "or_continue_with": "أو المتابعة بواسطة",
+    "google": "جوجل",
+    "apple": "أبل",
+    "no_account": "ليس لديك حساب؟ ",
+    "sign_up": "إنشاء حساب"
+  },
+  "register": {
+    "title": "إنشاء حساب",
+    "subtitle": "يرجى إدخال بياناتك للاستمتاع بالتطبيق",
+    "username": "اسم المستخدم",
+    "email": "البريد الإلكتروني",
+    "password": "كلمة المرور",
+    "confirm_password": "تأكيد كلمة المرور",
+    "remember_me": "تذكرني",
+    "create_account": "إنشاء حساب",
+    "creating_account": "جارٍ إنشاء الحساب...",
+    "or_use": "أو استخدم",
+    "google": "جوجل",
+    "apple": "أبل",
+    "already_have_account": "لديك حساب بالفعل؟ ",
+    "login": "تسجيل الدخول"
+  },
+  "settings": {
+    "title": "الإعدادات",
+    "subtitle": "تخصيص تفضيلات التطبيق.",
+    "notifications": "الإشعارات",
+    "currency": "العملة",
+    "update_info": "تحديث المعلومات",
+    "updating": "جارٍ التحديث..."
+  }
+}

--- a/utils/locales/en/translation.json
+++ b/utils/locales/en/translation.json
@@ -1,0 +1,50 @@
+{
+  "languages": {
+    "title": "Languages",
+    "subtitle": "Change the app language.",
+    "change": "Change language",
+    "changing": "Changing...",
+    "success_title": "Success",
+    "success_message": "Language changed successfully",
+    "error_title": "Error",
+    "error_message": "Failed to change language. Please try again."
+  },
+  "login": {
+    "title": "Login",
+    "subtitle": "Please enter your email and password to enjoy the experience",
+    "email": "Email",
+    "password": "Password",
+    "forgot_password": "Forget Password?",
+    "login_button": "Login",
+    "logging_in": "Logging in...",
+    "or_continue_with": "Or Continue with",
+    "google": "Google",
+    "apple": "Apple",
+    "no_account": "Didn't have an account? ",
+    "sign_up": "Sign Up"
+  },
+  "register": {
+    "title": "Create an Account",
+    "subtitle": "Please enter your details to enjoy the experience",
+    "username": "Username",
+    "email": "Email",
+    "password": "Password",
+    "confirm_password": "Confirm Password",
+    "remember_me": "Remember me",
+    "create_account": "Create an Account",
+    "creating_account": "Creating Account...",
+    "or_use": "OR use",
+    "google": "Google",
+    "apple": "Apple",
+    "already_have_account": "Already have an account? ",
+    "login": "Log In"
+  },
+  "settings": {
+    "title": "Settings",
+    "subtitle": "Customize app preferences.",
+    "notifications": "Notifications",
+    "currency": "Currency",
+    "update_info": "Update Info",
+    "updating": "Updating..."
+  }
+}

--- a/utils/locales/fr/translation.json
+++ b/utils/locales/fr/translation.json
@@ -1,0 +1,50 @@
+{
+  "languages": {
+    "title": "Langues",
+    "subtitle": "Changer la langue de l'application.",
+    "change": "Changer la langue",
+    "changing": "Changement...",
+    "success_title": "Succès",
+    "success_message": "Langue changée avec succès",
+    "error_title": "Erreur",
+    "error_message": "Échec du changement de langue. Veuillez réessayer."
+  },
+  "login": {
+    "title": "Connexion",
+    "subtitle": "Veuillez entrer votre email et mot de passe pour profiter de l'application",
+    "email": "Email",
+    "password": "Mot de passe",
+    "forgot_password": "Mot de passe oublié ?",
+    "login_button": "Se connecter",
+    "logging_in": "Connexion...",
+    "or_continue_with": "Ou continuer avec",
+    "google": "Google",
+    "apple": "Apple",
+    "no_account": "Vous n'avez pas de compte ? ",
+    "sign_up": "S'inscrire"
+  },
+  "register": {
+    "title": "Créer un compte",
+    "subtitle": "Veuillez entrer vos informations pour profiter de l'application",
+    "username": "Nom d'utilisateur",
+    "email": "Email",
+    "password": "Mot de passe",
+    "confirm_password": "Confirmer le mot de passe",
+    "remember_me": "Se souvenir de moi",
+    "create_account": "Créer un compte",
+    "creating_account": "Création du compte...",
+    "or_use": "Ou utiliser",
+    "google": "Google",
+    "apple": "Apple",
+    "already_have_account": "Vous avez déjà un compte ? ",
+    "login": "Se connecter"
+  },
+  "settings": {
+    "title": "Paramètres",
+    "subtitle": "Personnaliser les préférences de l'application.",
+    "notifications": "Notifications",
+    "currency": "Devise",
+    "update_info": "Mettre à jour",
+    "updating": "Mise à jour..."
+  }
+}


### PR DESCRIPTION
## Summary
- configure i18next with async language detector
- wrap app with `I18nextProvider`
- create translation JSON files for English, Arabic and French
- integrate translations on language selection, login, register and settings screens

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*
- `npx prettier -c "**/*.{js,jsx,ts,tsx,json}"` *(fails: Cannot find module 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_685423086a9083308b178a37e99a7a55